### PR TITLE
Use the new brew download link to verify sha

### DIFF
--- a/.github/workflows/new-pr-on-dispatch.yml
+++ b/.github/workflows/new-pr-on-dispatch.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Double check sha and tag
         run: |
-          curl -L -o subo.tar.gz https://github.com/suborbital/subo/archive/v${{ github.event.client_payload.tag }}.tar.gz
+          curl -L -o subo.tar.gz https://download.suborbital.network/subo/brew/{{ github.event.client_payload.tag }}
           echo ${{ github.event.client_payload.sha }} subo.tar.gz | sha256sum --check
           rm subo.tar.gz
       - name: Creates new file


### PR DESCRIPTION
Closes #5 

Again

Verified the hash locally when downloading from the new link that brew uses